### PR TITLE
chore: Initialize Claude Code config and update nixpkgs to release-26.05

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 To activate the home configuration for the current user and host:
 
 ```sh
-nix run home-manager/release-25.05 -- switch --flake .#$(whoami)@$(hostname -s)
+nix run home-manager/release-26.05 -- switch --flake .#$(whoami)@$(hostname -s)
 ```
 
 To update flake inputs (e.g., nixpkgs, home-manager):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+<!-- markdownlint-disable MD013 -->
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Applying Configuration
+
+To activate the home configuration for the current user and host:
+
+```sh
+nix run home-manager/release-25.05 -- switch --flake .#$(whoami)@$(hostname -s)
+```
+
+To update flake inputs (e.g., nixpkgs, home-manager):
+
+```sh
+nix flake update
+```
+
+## Linting
+
+YAML files are linted with yamllint (run in CI on every PR and push to main):
+
+```sh
+yamllint --format github --strict .
+```
+
+## Architecture
+
+**`flake.nix`** is the entry point. It defines `homeConfigurations` as a map of `"username@hostname"` strings to Home Manager configurations built via `mkHomeConfig { system, modulePaths }`. Each entry composes modules from `home/<user>/` and `modules/home-manager/`.
+
+**`home/<user>/<host>.nix`** is the per-host config. It imports `./global` (which imports the shared `outputs.homeManagerModules.commons` module) and sets host-specific values like `home.homeDirectory` and `home.stateVersion`. User-level packages, git config, GPG, and SSH live in `home/<user>/global/default.nix`.
+
+**`modules/home-manager/commons.nix`** is the shared base. It installs all common packages (`home.packages`), links asset files into `$XDG_CONFIG_HOME` via `home.file`, and configures zsh (with Oh My Zsh), starship, and shell aliases.
+
+**`modules/home-manager/assets/`** contains raw config files for tools (Neovim/LazyVim, WezTerm, tmux, starship, btop, fastfetch, git ignore). These are symlinked into place by `commons.nix`.
+
+**`overlays/default.nix`** defines three overlays: `additions` (custom pkgs), `modifications` (overrides), and `unstable-packages` (exposes `pkgs.unstable` backed by `nixpkgs-unstable`). Access unstable packages in any module as `pkgs.unstable.<name>`.
+
+**`pkgs/default.nix`** and **`overlays/default.nix`** work together: `overlays.additions` imports pkgs through the final nixpkgs set, making custom packages available as `pkgs.<name>`.
+
+## Adding a New Host or User
+
+1. Add an entry to `homeConfigurations` in `flake.nix` with the `"username@hostname"` key.
+2. Create `home/<user>/<host>.nix` (import `./global`, set `home.homeDirectory` and `home.stateVersion`).
+3. Create `home/<user>/global/default.nix` for user-specific packages, git config, etc.
+
+## CI / Release
+
+- **build** workflow: runs `yamllint` on PRs and pushes to `main`, plus weekly on Wednesdays.
+- **deploy** workflow: triggers `release-please` after a successful build on `main` to manage changelog and releases.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ homeConfigurations = {
 Apply the home configuration with a username and host combination.
 
 ```sh
-nix run home-manager/release-25.05 -- switch --flake .#$(whoami)@$(hostname -s)
+nix run home-manager/release-26.05 -- switch --flake .#$(whoami)@$(hostname -s)
 ```
 
 ## Acknowledgements

--- a/flake.lock
+++ b/flake.lock
@@ -7,32 +7,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1763992789,
-        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.05",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "Aglorei's Home Configuration";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
-    home-manager.url = "github:nix-community/home-manager/release-25.05";
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
## Changes

- **Added `CLAUDE.md`** — Codebase guidance for Claude Code covering how to apply configuration, lint YAML, repo architecture, adding new hosts/users, and CI/release workflow.
- **Updated nixpkgs to `26.05`** — Bumped `nixpkgs` input from `nixos-25.05` → `nixos-26.05` and `home-manager` from `release-25.05` → `release-26.05` in `flake.nix`.
- **Updated `flake.lock`** — Pinned both inputs to their latest `26.05` revisions.
- **Updated docs** — `README.md` and `CLAUDE.md` switch command updated to reference `home-manager/release-26.05`.

## Test plan

- [x] Run `nix run home-manager/release-26.05 -- switch --flake .#$(whoami)@$(hostname -s)` and verify activation succeeds
- [x] Confirm `yamllint --format github --strict .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)