### PR TITLE
docs: Improve CLAUDE.md agentic coding conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,16 @@ yamllint --format github --strict .
 2. Create `home/<user>/<host>.nix` (import `./global`, set `home.homeDirectory` and `home.stateVersion`).
 3. Create `home/<user>/global/default.nix` for user-specific packages, git config, etc.
 
+## Commit Style
+
+Use [Conventional Commits](https://www.conventionalcommits.org/). Capitalize the first word after the type prefix:
+
+```
+docs: Add validation step
+feat: Add new host config
+chore: Update nixpkgs input
+```
+
 ## CI / Release
 
 - **build** workflow: runs `yamllint` on PRs and pushes to `main`, plus weekly on Wednesdays.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Validation
+
+Before applying any configuration change, verify the flake is valid:
+
+```sh
+nix flake check
+```
+
 ## Applying Configuration
 
 To activate the home configuration for the current user and host:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ To activate the home configuration for the current user and host:
 nix run home-manager/release-26.05 -- switch --flake .#$(whoami)@$(hostname -s)
 ```
 
+> **Note:** This command mutates the live environment. It should only be run by the user, never autonomously by an agent.
+
 To update flake inputs (e.g., nixpkgs, home-manager):
 
 ```sh


### PR DESCRIPTION
## Summary

- Add `nix flake check` as the standard validation step before applying any config change
- Clarify that `home-manager switch` mutates the live environment and must be user-initiated, never run autonomously by an agent
- Add Conventional Commits style guide (capitalize first word after type prefix)

## Test plan

- [x] Review CLAUDE.md changes look correct
- [x] yamllint passes (no YAML files changed, but CI will confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)