### PR TITLE
fix: Grant pull-requests write permission to claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

- The `claude-code-review` workflow was completing successfully but posting no PR comments
- Root cause: `pull-requests: read` permission prevented Claude from writing review comments back to the PR
- Fix: change to `pull-requests: write`

## Test plan

- [x] Merge this PR and open a new PR to verify Claude Code Review posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)