### PR TITLE
chore: Remove aichat package

### DIFF
--- a/home/aglorei/global/default.nix
+++ b/home/aglorei/global/default.nix
@@ -16,10 +16,6 @@
 
   home.username = "aglorei";
 
-  home.packages = [
-    pkgs.unstable.aichat
-  ];
-
   # Cryptography
   programs.gpg.enable = true;
 


### PR DESCRIPTION
## Summary

- Removes `pkgs.unstable.aichat` from `home/aglorei/global/default.nix`
- Drops the now-empty `home.packages` block entirely

## Test plan

- [x] `nix flake check` passes
- [x] `nix run home-manager/release-26.05 -- switch --flake .#aglorei@<host>` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)