### PR TITLE
feat: Add ~/.local/bin to session PATH

### DIFF
--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -100,6 +100,10 @@
     ".tmux.conf".source = ./assets/tmux/tmux.conf;
   };
 
+  home.sessionPath = [
+    "$HOME/.local/bin"
+  ];
+
   # Home-Manager
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
## Summary

- Adds `$HOME/.local/bin` to `home.sessionPath` in `commons.nix` so it is prepended to `PATH` for all users and hosts
- Fixes the Claude Code diagnostic warning: *"Native installation exists but ~/.local/bin is not in your PATH"*

## Test plan

- [x] Run `nix flake check` — passes (validated locally)
- [x] Apply config with `nix run home-manager/release-26.05 -- switch --flake .#$(whoami)@$(hostname -s)` and confirm `~/.local/bin` appears in `$PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)