### PR TITLE
fix: Replace short GPG key ID and remove global SSH host checking bypass

### DIFF
--- a/home/aglorei/global/default.nix
+++ b/home/aglorei/global/default.nix
@@ -34,15 +34,13 @@
       commit.gpgSign = true;
       core.editor = "nvim";
       core.excludesFile = "${config.xdg.configHome}/git/ignore";
-      user.signing.key = "ED8839A2";
+      user.signing.key = "E9D93DFD65E441AC3F30E71F7C210B28ED8839A2";
     };
   };
 
   # SSH
   programs.ssh = {
     enable = true;
-    userKnownHostsFile = "/dev/null";
-    extraConfig = "StrictHostKeyChecking no";
     includes = ["config.local"];
   };
 }

--- a/home/tienlong.pham/global/default.nix
+++ b/home/tienlong.pham/global/default.nix
@@ -39,8 +39,6 @@
   # SSH
   programs.ssh = {
     enable = true;
-    userKnownHostsFile = "/dev/null";
-    extraConfig = "StrictHostKeyChecking no";
     includes = ["config.local"];
   };
 }


### PR DESCRIPTION
## Summary

- Replaces 8-character GPG signing key ID `ED8839A2` with the full 40-character fingerprint `E9D93DFD65E441AC3F30E71F7C210B28ED8839A2` to eliminate short ID collision vulnerability
- Removes global `StrictHostKeyChecking no` and `userKnownHostsFile=/dev/null` from both user SSH configs, restoring default strict host checking; host-specific exceptions can be placed in `config.local`

Closes #48, closes #54.

## Test plan

- [x] `nix flake check` passes
- [x] `nix run home-manager/release-26.05 -- switch --flake .#aglorei@$(hostname -s)` applies cleanly
- [x] SSH connections to known hosts work as expected; new/unknown hosts prompt for verification
- [x] Git commits are signed and verified with the updated key fingerprint

🤖 Generated with [Claude Code](https://claude.com/claude-code)