### PR TITLE
ci: Guard deploy on build success and scope code review to non-release-please PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,11 +13,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.user.login != 'release-please[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ run-name: ${{ github.event.workflow_run.display_title }}
 
 jobs:
   release-please:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

- Closes #58: `deploy` job now only runs when the triggering `build` workflow concluded with `success`, preventing releases on failed builds
- Closes #57: `claude-review` job skips PRs from `release-please[bot]`, whose output (CHANGELOG/version bumps) has no code logic worth reviewing; other bots (Copilot, Dependabot, etc.) remain in scope

## Test plan

- [ ] Verify `deploy` workflow does not trigger on a failed `build` run
- [ ] Verify `claude-review` does not run on the open release-please PR (#40)
- [ ] Verify `claude-review` still runs on a normal PR from `aglorei`

🤖 Generated with [Claude Code](https://claude.com/claude-code)