### PR TITLE
fix: Migrate deprecated home-manager options and resolve starship double-management

### DIFF
--- a/home/aglorei/global/default.nix
+++ b/home/aglorei/global/default.nix
@@ -27,9 +27,9 @@
   # SCM
   programs.git = {
     enable = true;
-    userName = config.home.username;
-    userEmail = "10876966+aglorei@users.noreply.github.com";
-    extraConfig = {
+    settings = {
+      user.name = config.home.username;
+      user.email = "10876966+aglorei@users.noreply.github.com";
       init.defaultBranch = "main";
       commit.gpgSign = true;
       core.editor = "nvim";
@@ -41,6 +41,7 @@
   # SSH
   programs.ssh = {
     enable = true;
+    enableDefaultConfig = false;
     includes = ["config.local"];
   };
 }

--- a/home/tienlong.pham/global/default.nix
+++ b/home/tienlong.pham/global/default.nix
@@ -29,7 +29,7 @@
   programs.git = {
     enable = true;
     includes = [{path = "${config.xdg.configHome}/git/config.local";}];
-    extraConfig = {
+    settings = {
       init.defaultBranch = "main";
       core.editor = "nvim";
       core.excludesFile = "${config.xdg.configHome}/git/ignore";
@@ -39,6 +39,7 @@
   # SSH
   programs.ssh = {
     enable = true;
+    enableDefaultConfig = false;
     includes = ["config.local"];
   };
 }

--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -41,7 +41,6 @@
 
     # Prompt
     pkgs.oh-my-zsh
-    pkgs.starship
 
     # Python
     pkgs.poetry
@@ -89,9 +88,6 @@
       recursive = true;
     };
 
-    # Prompt
-    "${config.xdg.configHome}/starship.toml".source = ./assets/starship/starship.toml;
-
     # SCM
     "${config.xdg.configHome}/git/ignore".source = ./assets/git/ignore;
 
@@ -108,7 +104,100 @@
   programs.home-manager.enable = true;
 
   # Prompt
-  programs.starship.enable = true;
+  programs.starship = {
+    enable = true;
+    settings = {
+      add_newline = false;
+      aws.symbol = "  ";
+      buf.symbol = " ";
+      c.symbol = " ";
+      cmake.symbol = " ";
+      conda.symbol = " ";
+      crystal.symbol = " ";
+      dart.symbol = " ";
+      directory.read_only = " 󰌾";
+      docker_context.symbol = " ";
+      elixir.symbol = " ";
+      elm.symbol = " ";
+      fennel.symbol = " ";
+      fossil_branch.symbol = " ";
+      git_branch.symbol = " ";
+      git_commit.tag_symbol = "  ";
+      golang.symbol = " ";
+      guix_shell.symbol = " ";
+      haskell.symbol = " ";
+      haxe.symbol = " ";
+      hg_branch.symbol = " ";
+      hostname.ssh_symbol = " ";
+      java.symbol = " ";
+      julia.symbol = " ";
+      kotlin.symbol = " ";
+      lua.symbol = " ";
+      memory_usage.symbol = "󰍛 ";
+      meson.symbol = "󰔷 ";
+      nim.symbol = "󰆥 ";
+      nix_shell.symbol = " ";
+      nodejs.symbol = " ";
+      ocaml.symbol = " ";
+      os.symbols = {
+        Alpaquita = " ";
+        Alpine = " ";
+        AlmaLinux = " ";
+        Amazon = " ";
+        Android = " ";
+        Arch = " ";
+        Artix = " ";
+        CentOS = " ";
+        Debian = " ";
+        DragonFly = " ";
+        Emscripten = " ";
+        EndeavourOS = " ";
+        Fedora = " ";
+        FreeBSD = " ";
+        Garuda = "󰛓 ";
+        Gentoo = " ";
+        HardenedBSD = "󰞌 ";
+        Illumos = "󰈸 ";
+        Kali = " ";
+        Linux = " ";
+        Mabox = " ";
+        Macos = " ";
+        Manjaro = " ";
+        Mariner = " ";
+        MidnightBSD = " ";
+        Mint = " ";
+        NetBSD = " ";
+        NixOS = " ";
+        OpenBSD = "󰈺 ";
+        openSUSE = " ";
+        OracleLinux = "󰌷 ";
+        Pop = " ";
+        Raspbian = " ";
+        Redhat = " ";
+        RedHatEnterprise = " ";
+        RockyLinux = " ";
+        Redox = "󰀘 ";
+        Solus = "󰠳 ";
+        SUSE = " ";
+        Ubuntu = " ";
+        Unknown = " ";
+        Void = " ";
+        Windows = "󰍲 ";
+      };
+      package.symbol = "󰏗 ";
+      perl.symbol = " ";
+      php.symbol = " ";
+      pijul_channel.symbol = " ";
+      python.symbol = " ";
+      rlang.symbol = "󰟔 ";
+      ruby.symbol = " ";
+      rust.symbol = "󱘗 ";
+      scala.symbol = " ";
+      swift.symbol = " ";
+      zig.symbol = " ";
+      gradle.symbol = " ";
+    };
+  };
 
   # Shell
   programs.zsh = {


### PR DESCRIPTION
## Summary

- Closes #55: Migrates deprecated `programs.git.{userName,userEmail,extraConfig}` → `programs.git.settings` and adds `programs.ssh.enableDefaultConfig = false` in both user configs. Compatibility shims will be removed in a future home-manager release.
- Closes #53: Resolves undefined behavior where `programs.starship.enable = true` and a `home.file` symlink both claimed ownership of `starship.toml`. Migrates the raw TOML to `programs.starship.settings` (1:1 conversion) and removes the symlink. The `pkgs.starship` entry in `home.packages` is also removed since `programs.starship.enable` handles installation.

## Test plan

- [x] `nix flake check` passes with no deprecation warnings
- [x] `nix run home-manager/release-26.05 -- switch --flake .#aglorei@$(hostname -s)` applies cleanly
- [x] Starship prompt renders correctly after activation
- [x] Git commits are still GPG-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)