### PR TITLE
ci: Add nix flake check to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,13 @@ jobs:
       - run: pip install --user yamllint
 
       - run: yamllint --format github --strict .
+
+  nix-flake-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: DeterminateSystems/nix-installer-action@v14
+
+      - run: nix flake check


### PR DESCRIPTION
## Summary

- Closes #56: Adds a `nix-flake-check` job to the `build` workflow using `DeterminateSystems/nix-installer-action` to install Nix, then runs `nix flake check` to validate flake outputs (overlays, homeManagerModules) on every PR and push to main.

## Test plan

- [x] `nix-flake-check` job passes on this PR
- [x] `yamllint` job still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)