### PR TITLE
refactor: P1 cleanups — remove redundant packages, fix homeDirectory placement, remove empty stubs

### DIFF
--- a/home/tienlong.pham/global/default.nix
+++ b/home/tienlong.pham/global/default.nix
@@ -15,7 +15,6 @@
   };
 
   home.username = "tienlong.pham";
-  home.homeDirectory = "/Users/${config.home.username}";
 
   # Cryptography
   programs.gpg.enable = true;

--- a/home/tienlong.pham/j2wnhywdqd.nix
+++ b/home/tienlong.pham/j2wnhywdqd.nix
@@ -1,5 +1,10 @@
-{pkgs, ...}: {
+{
+  config,
+  pkgs,
+  ...
+}: {
   imports = [./global];
 
+  home.homeDirectory = "/Users/${config.home.username}";
   home.stateVersion = "25.05";
 }

--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -16,9 +16,6 @@
     # Containers
     pkgs.kubectl
 
-    # Cryptography
-    pkgs.gnupg
-
     # Diagnostic
     pkgs.btop
     pkgs.fastfetch
@@ -39,21 +36,12 @@
     # NodeJS
     pkgs.nodejs
 
-    # Prompt
-    pkgs.oh-my-zsh
-
     # Python
     pkgs.poetry
     pkgs.python3
 
     # Rust
     pkgs.cargo
-
-    # SCM
-    pkgs.git
-
-    # Shell
-    pkgs.zsh
 
     # Terminal
     pkgs.tmux

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,13 +1,4 @@
 {inputs, ...}: {
-  additions = final: _prev: import ../pkgs final.pkgs;
-
-  # https://nixos.wiki/wiki/Overlays
-  modifications = final: prev: {
-    # example = prev.example.overrideAttrs (oldAttrs: rec {
-    # ...
-    # });
-  };
-
   # Unstable nixpkgs set declared in flake inputs accessed by 'pkgs.unstable'
   unstable-packages = final: _prev: {
     unstable = import inputs.nixpkgs-unstable {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,0 @@
-# Custom nixpkgs built using `nix build .#example`
-pkgs: {
-  # example = pkgs.callPackage ./example { };
-}


### PR DESCRIPTION
## Summary

- Remove `home.packages` entries for `git`, `gnupg`, `zsh`, and `oh-my-zsh` — each is already installed by its corresponding `programs.*` module (closes #49)
- Move `home.homeDirectory` from `tienlong.pham` global config into the host-specific `j2wnhywdqd.nix` where it belongs (closes #52)
- Delete `pkgs/default.nix` stub and remove unused `additions`/`modifications` overlays from `overlays/default.nix` (closes #50)

## Test plan

- [ ] `nix flake check` passes
- [ ] yamllint passes (no YAML changes in this PR)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)