### PR TITLE
security: Gate Claude workflows on author association

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,12 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login != 'release-please[bot]'
+    if: |
+      github.event.pull_request.user.login != 'release-please[bot]' &&
+      (github.event.pull_request.author_association == 'OWNER' ||
+       github.event.pull_request.author_association == 'MEMBER' ||
+       github.event.pull_request.author_association == 'COLLABORATOR' ||
+       github.event.pull_request.author_association == 'CONTRIBUTOR')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,15 +16,27 @@ jobs:
     if: |
       (github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)) ||
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR' ||
+         github.event.comment.author_association == 'CONTRIBUTOR')) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)) ||
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR' ||
+         github.event.comment.author_association == 'CONTRIBUTOR')) ||
       (github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.review.author_association)) ||
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
+         github.event.review.author_association == 'COLLABORATOR' ||
+         github.event.review.author_association == 'CONTRIBUTOR')) ||
       (github.event_name == 'issues' &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.issue.author_association) &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR' ||
+         github.event.issue.author_association == 'CONTRIBUTOR') &&
         (contains(github.event.issue.body, '@claude') ||
          contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,14 +15,18 @@ jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (
-        contains(github.event.issue.body, '@claude') ||
-        contains(github.event.issue.title, '@claude')))
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.issue.author_association) &&
+        (contains(github.event.issue.body, '@claude') ||
+         contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- **claude-code-review.yml**: adds `author_association` check so automatic reviews only run on PRs from OWNER, MEMBER, COLLABORATOR, or CONTRIBUTOR — prevents free reviews for arbitrary external PRs
- **claude.yml**: adds per-event `author_association` check (using `fromJSON` array membership) so `@claude` triggers are ignored from users with no established relationship to the repo — prevents quota exhaustion from comment spam

## Test plan

- [x] Confirm CI (yamllint) passes on this PR
- [x] Verify a comment with `@claude` from the repo owner still triggers the workflow
- [x] Verify the code review workflow still runs on PRs from the owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)