### PR TITLE
docs: Add docs/ directory and close issue #64

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ See [`docs/architecture.md`](docs/architecture.md) for the full walkthrough.
 ## Adding a New Host or User
 
 1. Add `"username@hostname"` to `homeConfigurations` in `flake.nix`.
-2. Create `home/<user>/<host>.nix` — import `./global`, set `home.homeDirectory` and `home.stateVersion`.
-3. Create `home/<user>/global/default.nix` — import `outputs.homeManagerModules.commons`, apply `outputs.overlays.unstable-packages`.
+2. Create `home/<user>/<host>.nix`: import `./global`, set `home.homeDirectory` and `home.stateVersion`.
+3. Create `home/<user>/global/default.nix`: import `outputs.homeManagerModules.commons`, apply `outputs.overlays.unstable-packages`.
 
 See [`docs/onboarding.md`](docs/onboarding.md) for the full procedure with examples.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,35 +39,25 @@ yamllint --format github --strict .
 
 ## Architecture
 
-**`flake.nix`** is the entry point. It defines `homeConfigurations` as a map of `"username@hostname"` strings to Home Manager configurations built via `mkHomeConfig { system, modulePaths }`. Each entry composes modules from `home/<user>/` and `modules/home-manager/`.
+Layers: `flake.nix` → `home/<user>/<host>.nix` → `home/<user>/global/default.nix` → `modules/home-manager/commons.nix` → `modules/home-manager/assets/`. Do not update `home.stateVersion` after initial deployment. Unstable packages are available as `pkgs.unstable.<name>` via the overlay in `overlays/default.nix`.
 
-**`home/<user>/<host>.nix`** is the per-host config. It imports `./global` and sets `home.homeDirectory` and `home.stateVersion`. Do not update `home.stateVersion` after initial deployment — it should reflect the NixOS release when that user's config was first activated, not the current release.
-
-**`home/<user>/global/default.nix`** imports `outputs.homeManagerModules.commons` and sets user-level config: git (with GPG signing), GPG agent (`pinentry-curses`), and SSH. SSH is configured with `enableDefaultConfig = false` and `includes = ["config.local"]` so machine-specific host entries can live in an untracked `~/.ssh/config.local`.
-
-**`modules/home-manager/commons.nix`** is the shared base. It installs all common packages (`home.packages`), links asset files into `$XDG_CONFIG_HOME` via `home.file`, and configures zsh (with Oh My Zsh), starship, and shell aliases.
-
-**`modules/home-manager/assets/`** contains raw config files for tools (Neovim/LazyVim, WezTerm, tmux, btop, fastfetch, git ignore). These are symlinked into place by `commons.nix`.
-
-**`overlays/default.nix`** defines the `unstable-packages` overlay, which exposes `pkgs.unstable` backed by `nixpkgs-unstable`. Access unstable packages in any module as `pkgs.unstable.<name>`. The overlay is applied per-user in `home/<user>/global/default.nix` via `nixpkgs.overlays`.
+See [`docs/architecture.md`](docs/architecture.md) for the full walkthrough.
 
 ## Adding a New Host or User
 
-1. Add an entry to `homeConfigurations` in `flake.nix` with the `"username@hostname"` key.
-2. Create `home/<user>/<host>.nix` (import `./global`, set `home.homeDirectory` and `home.stateVersion`).
-3. Create `home/<user>/global/default.nix` for user-specific packages, git config, etc. Import `outputs.homeManagerModules.commons` and apply `outputs.overlays.unstable-packages`.
+1. Add `"username@hostname"` to `homeConfigurations` in `flake.nix`.
+2. Create `home/<user>/<host>.nix` — import `./global`, set `home.homeDirectory` and `home.stateVersion`.
+3. Create `home/<user>/global/default.nix` — import `outputs.homeManagerModules.commons`, apply `outputs.overlays.unstable-packages`.
+
+See [`docs/onboarding.md`](docs/onboarding.md) for the full procedure with examples.
 
 ## Commit Style
 
-Use [Conventional Commits](https://www.conventionalcommits.org/). Capitalize the first word after the type prefix:
-
-```
-docs: Add validation step
-feat: Add new host config
-chore: Update nixpkgs input
-```
+Use [Conventional Commits](https://www.conventionalcommits.org/). Capitalize the first word after the type prefix: `docs: Add validation step`. See [`docs/style.md`](docs/style.md) for the full style guide including Nix conventions.
 
 ## CI / Release
 
-- **build** workflow: runs `yamllint` on PRs and pushes to `main`, plus weekly on Wednesdays.
-- **deploy** workflow: triggers `release-please` after a successful build on `main` to manage changelog and releases.
+- **build** workflow: runs `yamllint` and `nix flake check` on PRs and pushes to `main`, plus weekly on Wednesdays.
+- **deploy** workflow: triggers `release-please` after a successful `build` on `main`.
+
+See [`docs/ci.md`](docs/ci.md) for the full workflow inventory.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Configurations that I use in a [flakes](https://wiki.nixos.org/wiki/Flakes) appr
 ### Editor
 
 - [Neovim](https://neovim.io/) with [LazyVim](https://www.lazyvim.org/)
-- Custom plugins and configuration in `modules/home-manager/assets/nvim/`
 
 ### Terminal
 
-- [WezTerm](https://wezfurlong.org/wezterm/) (see `modules/home-manager/assets/wezterm/wezterm.lua`)
+- [WezTerm](https://wezfurlong.org/wezterm/)
 
 ### Font
 
@@ -28,12 +27,16 @@ Configurations that I use in a [flakes](https://wiki.nixos.org/wiki/Flakes) appr
 
 - [Kanagawa](https://github.com/rebelot/kanagawa.nvim) (for Neovim and terminal)
 
+See [docs/customization.md](docs/customization.md) for configuration details.
+
 ## Structure
 
 - `flake.nix`: Flake entrypoint, defines system/home-manager configurations.
 - `modules/home-manager/`: Home Manager modules and assets (Neovim, WezTerm, etc).
 - `home/<user>/<host>.nix`: Per-user, per-host Home Manager configs.
-- `pkgs/` and `overlays/`: Custom packages and overlays.
+- `overlays/`: Custom Nix overlays.
+
+See [docs/architecture.md](docs/architecture.md) for a full architecture walkthrough.
 
 ## Installation
 
@@ -61,30 +64,9 @@ nix-channel --update
 
 Optionally, enable flakes as an experimental feature [without additional command-line options](https://wiki.nixos.org/wiki/Flakes#Other_Distros,_without_Home-Manager).
 
-### Step 3: Initialize Configuration
+### Steps 3–4: Configure and Activate
 
-Include a `homeConfigurations` username and host combination (i.e., `echo $(whoami)@$(hostname -s)`) in [flake.nix](./flake.nix).
-
-```nix
-homeConfigurations = {
-  # Replace with your username@hostname
-  "your-username@your-hostname" = mkHomeConfig {
-    system = "aarch64-darwin"; # or x86_64-darwin/linux
-    modulePaths = [
-      ./home/your-username/your-hostname.nix
-      # > include additional nixes <
-    ];
-  };
-};
-```
-
-### Step 4: Activate Configuration
-
-Apply the home configuration with a username and host combination.
-
-```sh
-nix run home-manager/release-26.05 -- switch --flake .#$(whoami)@$(hostname -s)
-```
+See [docs/onboarding.md](docs/onboarding.md) for adding a host configuration and activating it.
 
 ## Acknowledgements
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,12 +63,12 @@ Raw configuration files symlinked into place at activation:
 
 | Tool | Asset path | Destination |
 |---|---|---|
-| btop | `assets/btop/` | `$XDG_CONFIG_HOME/btop/` |
-| fastfetch | `assets/fastfetch/` | `$XDG_CONFIG_HOME/fastfetch/` |
-| Neovim | `assets/nvim/` | `$XDG_CONFIG_HOME/nvim/` |
-| WezTerm | `assets/wezterm/wezterm.lua` | `$XDG_CONFIG_HOME/wezterm/wezterm.lua` |
-| tmux | `assets/tmux/tmux.conf` | `~/.tmux.conf` |
-| git ignore | `assets/git/ignore` | `$XDG_CONFIG_HOME/git/ignore` |
+| btop | `modules/home-manager/assets/btop/` | `$XDG_CONFIG_HOME/btop/` |
+| fastfetch | `modules/home-manager/assets/fastfetch/` | `$XDG_CONFIG_HOME/fastfetch/` |
+| Neovim | `modules/home-manager/assets/nvim/` | `$XDG_CONFIG_HOME/nvim/` |
+| WezTerm | `modules/home-manager/assets/wezterm/wezterm.lua` | `$XDG_CONFIG_HOME/wezterm/wezterm.lua` |
+| tmux | `modules/home-manager/assets/tmux/tmux.conf` | `~/.tmux.conf` |
+| git ignore | `modules/home-manager/assets/git/ignore` | `$XDG_CONFIG_HOME/git/ignore` |
 
 Starship is configured directly in `commons.nix` via `programs.starship.settings`; there is no linked file.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,77 @@
+<!-- markdownlint-disable MD013 -->
+# Architecture
+
+## Layer Overview
+
+```
+flake.nix
+  └── home/<user>/<host>.nix
+        └── home/<user>/global/default.nix
+              └── modules/home-manager/commons.nix
+                    └── modules/home-manager/assets/
+```
+
+| Layer | Responsibility |
+|---|---|
+| `flake.nix` | Entry point; defines inputs, `mkHomeConfig`, and `homeConfigurations` |
+| `home/<user>/<host>.nix` | Per-host settings: `home.homeDirectory`, `home.stateVersion` |
+| `home/<user>/global/default.nix` | Per-user drop-in: git, GPG, SSH, user-specific packages |
+| `modules/home-manager/commons.nix` | Shared base: packages, asset symlinking, zsh, starship |
+| `modules/home-manager/assets/` | Raw config files symlinked into `$XDG_CONFIG_HOME` |
+
+## flake.nix
+
+Defines two inputs — `nixpkgs` (stable) and `nixpkgs-unstable` — and the `mkHomeConfig` helper, which wraps `homeManagerConfiguration` and accepts a `system` string and a list of `modulePaths`. Each entry in `homeConfigurations` is a `"username@hostname"` string mapped to a `mkHomeConfig` call.
+
+## home/\<user\>/\<host\>.nix
+
+The per-host file has two jobs: import `./global` and set the two host-specific values.
+
+```nix
+{ config, ... }: {
+  imports = [ ./global ];
+
+  home.homeDirectory = "/Users/${config.home.username}";
+  home.stateVersion = "26.05";
+}
+```
+
+> **`home.stateVersion`** should be set to the NixOS release at the time of first activation and never updated afterward. It governs state migration behavior in Home Manager; changing it after the fact can corrupt managed state.
+
+## home/\<user\>/global/default.nix
+
+A personal drop-in. The only required wiring is importing `outputs.homeManagerModules.commons` and applying `outputs.overlays.unstable-packages`. Everything else — git identity, GPG agent, SSH config, additional packages — is user-defined.
+
+```nix
+{ pkgs, outputs, ... }: {
+  imports = [ outputs.homeManagerModules.commons ];
+
+  nixpkgs.overlays = [ outputs.overlays.unstable-packages ];
+
+  home.username = "your-username";
+  # user-specific config here
+}
+```
+
+## modules/home-manager/commons.nix
+
+The shared base module. Installs common packages via `home.packages`, symlinks asset directories into `$XDG_CONFIG_HOME` via `home.file`, and configures zsh (with Oh My Zsh) and starship. Everything in this module applies to all users.
+
+## modules/home-manager/assets/
+
+Raw configuration files symlinked into place at activation:
+
+| Tool | Asset path | Destination |
+|---|---|---|
+| btop | `assets/btop/` | `$XDG_CONFIG_HOME/btop/` |
+| fastfetch | `assets/fastfetch/` | `$XDG_CONFIG_HOME/fastfetch/` |
+| Neovim | `assets/nvim/` | `$XDG_CONFIG_HOME/nvim/` |
+| WezTerm | `assets/wezterm/wezterm.lua` | `$XDG_CONFIG_HOME/wezterm/wezterm.lua` |
+| tmux | `assets/tmux/tmux.conf` | `~/.tmux.conf` |
+| git ignore | `assets/git/ignore` | `$XDG_CONFIG_HOME/git/ignore` |
+
+Starship is configured directly in `commons.nix` via `programs.starship.settings` — there is no linked file.
+
+## overlays/default.nix
+
+Defines the `unstable-packages` overlay, which makes the `nixpkgs-unstable` package set available as `pkgs.unstable`. Applied in `home/<user>/global/default.nix` via `nixpkgs.overlays`. Access unstable packages in any module as `pkgs.unstable.<name>`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ flake.nix
 
 ## flake.nix
 
-Defines two inputs — `nixpkgs` (stable) and `nixpkgs-unstable` — and the `mkHomeConfig` helper, which wraps `homeManagerConfiguration` and accepts a `system` string and a list of `modulePaths`. Each entry in `homeConfigurations` is a `"username@hostname"` string mapped to a `mkHomeConfig` call.
+Defines two inputs, `nixpkgs` (stable) and `nixpkgs-unstable`, and the `mkHomeConfig` helper, which wraps `homeManagerConfiguration` and accepts a `system` string and a list of `modulePaths`. Each entry in `homeConfigurations` is a `"username@hostname"` string mapped to a `mkHomeConfig` call.
 
 ## home/\<user\>/\<host\>.nix
 
@@ -40,7 +40,7 @@ The per-host file has two jobs: import `./global` and set the two host-specific 
 
 ## home/\<user\>/global/default.nix
 
-A personal drop-in. The only required wiring is importing `outputs.homeManagerModules.commons` and applying `outputs.overlays.unstable-packages`. Everything else — git identity, GPG agent, SSH config, additional packages — is user-defined.
+A personal drop-in. The only required wiring is importing `outputs.homeManagerModules.commons` and applying `outputs.overlays.unstable-packages`. Everything else (git identity, GPG agent, SSH config, additional packages) is user-defined.
 
 ```nix
 { pkgs, outputs, ... }: {
@@ -70,7 +70,7 @@ Raw configuration files symlinked into place at activation:
 | tmux | `assets/tmux/tmux.conf` | `~/.tmux.conf` |
 | git ignore | `assets/git/ignore` | `$XDG_CONFIG_HOME/git/ignore` |
 
-Starship is configured directly in `commons.nix` via `programs.starship.settings` — there is no linked file.
+Starship is configured directly in `commons.nix` via `programs.starship.settings`; there is no linked file.
 
 ## overlays/default.nix
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD013 -->
+# CI
+
+## Workflow Overview
+
+| Workflow | Triggers | Jobs |
+|---|---|---|
+| `build` | PR to `main`, push to `main`, weekly (Wed) | `yamllint`, `nix-flake-check` |
+| `deploy` | `build` completes on `main` | `release-please` |
+| `claude-code-review` | PR opened/updated | `claude-review` |
+| `claude` | Issue/PR comments and reviews mentioning `@claude` | `claude` |
+
+## CI/CD Flow
+
+`build` runs on every PR and push to `main`. The `deploy` workflow triggers via `workflow_run` and gates on `build` concluding with `success`, so release-please only fires after a passing build.
+
+Release management uses [release-please](https://github.com/googleapis/release-please) with `release-type: simple`. It reads Conventional Commit history to determine version bumps and generates `CHANGELOG.md` entries.
+
+## Conventions
+
+- **YAML linting** is CI-only. `.yamllint.yml` is the config; `build` is the authoritative check.
+- **Flake validation** runs `nix flake check` via [DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action).
+- **Claude workflows** require the `CLAUDE_CODE_OAUTH_TOKEN` secret.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@
 | `build` | PR to `main`, push to `main`, weekly (Wed) | `yamllint`, `nix-flake-check` |
 | `deploy` | `build` completes on `main` | `release-please` |
 | `claude-code-review` | PR opened/updated | `claude-review` |
-| `claude` | Issue/PR comments and reviews mentioning `@claude` | `claude` |
+| `claude` | Issues opened/assigned, and issue/PR comments and reviews mentioning `@claude` | `claude` |
 
 ## CI/CD Flow
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -18,10 +18,10 @@ Starship is configured directly in `commons.nix` via `programs.starship.settings
 
 ## Neovim (LazyVim)
 
-Entry point: `assets/nvim/init.lua` bootstraps [LazyVim](https://www.lazyvim.org/).
+Entry point: `modules/home-manager/assets/nvim/init.lua` bootstraps [LazyVim](https://www.lazyvim.org/).
 
 ```
-assets/nvim/
+modules/home-manager/assets/nvim/
   init.lua               # LazyVim bootstrap
   lua/
     config/

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,72 @@
+<!-- markdownlint-disable MD013 -->
+# Customization
+
+## Asset Overview
+
+`modules/home-manager/commons.nix` symlinks these files into place at activation:
+
+| Tool | Repo path | Destination |
+|---|---|---|
+| btop | `modules/home-manager/assets/btop/` | `$XDG_CONFIG_HOME/btop/` |
+| fastfetch | `modules/home-manager/assets/fastfetch/` | `$XDG_CONFIG_HOME/fastfetch/` |
+| Neovim | `modules/home-manager/assets/nvim/` | `$XDG_CONFIG_HOME/nvim/` |
+| WezTerm | `modules/home-manager/assets/wezterm/wezterm.lua` | `$XDG_CONFIG_HOME/wezterm/wezterm.lua` |
+| tmux | `modules/home-manager/assets/tmux/tmux.conf` | `~/.tmux.conf` |
+| git ignore | `modules/home-manager/assets/git/ignore` | `$XDG_CONFIG_HOME/git/ignore` |
+
+Starship is configured directly in `commons.nix` via `programs.starship.settings` — there is no standalone config file to edit.
+
+## Neovim (LazyVim)
+
+Entry point: `assets/nvim/init.lua` bootstraps [LazyVim](https://www.lazyvim.org/).
+
+```
+assets/nvim/
+  init.lua               # LazyVim bootstrap
+  lua/
+    config/
+      autocmds.lua
+      keymaps.lua
+      options.lua
+      lazy.lua
+    plugins/
+      kanagawa.lua       # colorscheme
+```
+
+To add a plugin, create a new file under `lua/plugins/` following the [LazyVim plugin spec](https://www.lazyvim.org/configuration/plugins).
+
+## WezTerm
+
+Single config file: `assets/wezterm/wezterm.lua`. Color scheme is set to Kanagawa.
+
+## tmux
+
+Config file: `assets/tmux/tmux.conf`. The shell alias `hack` (defined in `commons.nix`) attaches to or creates a session named `hack`: `tmux a -t hack || tmux new -s hack`.
+
+## Starship
+
+Configured inline in `commons.nix` under `programs.starship.settings`. To add or remove prompt modules, edit that block directly.
+
+## btop
+
+Config and theme files live in `assets/btop/`. The Kanagawa theme is at `assets/btop/themes/kanagawa.theme`.
+
+## fastfetch
+
+Config at `assets/fastfetch/config.jsonc`.
+
+## Theme Cohesion
+
+[Kanagawa](https://github.com/rebelot/kanagawa.nvim) is used across Neovim (`lua/plugins/kanagawa.lua`) and WezTerm. To swap themes, update both.
+
+## Unstable Packages
+
+The `unstable-packages` overlay exposes `nixpkgs-unstable` as `pkgs.unstable`. To add an unstable package, reference it in `home.packages` within `commons.nix` or your user's `global/default.nix`:
+
+```nix
+home.packages = [
+  pkgs.unstable.some-package
+];
+```
+
+The overlay is applied in each user's `global/default.nix`. See [`docs/architecture.md`](architecture.md) for details.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -14,7 +14,7 @@
 | tmux | `modules/home-manager/assets/tmux/tmux.conf` | `~/.tmux.conf` |
 | git ignore | `modules/home-manager/assets/git/ignore` | `$XDG_CONFIG_HOME/git/ignore` |
 
-Starship is configured directly in `commons.nix` via `programs.starship.settings` — there is no standalone config file to edit.
+Starship is configured directly in `commons.nix` via `programs.starship.settings`; there is no standalone config file to edit.
 
 ## Neovim (LazyVim)
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,55 @@
+<!-- markdownlint-disable MD013 -->
+# Onboarding
+
+## Adding a Host for an Existing User
+
+**1. Add an entry to `homeConfigurations` in `flake.nix`:**
+
+```nix
+homeConfigurations = {
+  "username@hostname" = mkHomeConfig {
+    system = "aarch64-darwin"; # or x86_64-linux, x86_64-darwin
+    modulePaths = [
+      ./home/username/hostname.nix
+    ];
+  };
+};
+```
+
+**2. Create `home/<user>/<host>.nix`:**
+
+```nix
+{ config, ... }: {
+  imports = [ ./global ];
+
+  home.homeDirectory = "/Users/${config.home.username}"; # or /home/... on Linux
+  home.stateVersion = "26.05"; # set to the current NixOS release; never update after first activation
+}
+```
+
+**3. Validate and activate:**
+
+```sh
+nix flake check
+nix run home-manager/release-26.05 -- switch --flake .#username@hostname
+```
+
+## Adding a New User
+
+Everything in the previous section, plus:
+
+**Create `home/<user>/global/default.nix`:**
+
+```nix
+{ pkgs, outputs, ... }: {
+  imports = [ outputs.homeManagerModules.commons ];
+
+  nixpkgs.overlays = [ outputs.overlays.unstable-packages ];
+
+  home.username = "your-username";
+
+  # User-specific config: git identity, GPG agent, SSH, additional packages, etc.
+}
+```
+
+`global/default.nix` is a personal drop-in. Importing `commons` and applying the overlay are the only required pieces; everything else is up to the user. See [`docs/architecture.md`](architecture.md) for how the layers compose.

--- a/docs/style.md
+++ b/docs/style.md
@@ -37,7 +37,7 @@ programs.git = { enable = true; settings = { ... }; };
 # good
 { pkgs, config, ... }: { ... }
 
-# avoid — lists unused args
+# avoid: lists unused args
 { pkgs, config, lib, inputs, outputs, ... }: { ... }
 ```
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,0 +1,60 @@
+<!-- markdownlint-disable MD013 -->
+# Style Guide
+
+## Commit Messages
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/). Capitalize the first word after the type prefix:
+
+```
+feat: Add new host config
+fix: Correct stateVersion for mikasa
+chore: Update nixpkgs input
+docs: Add architecture overview
+refactor: Extract shared overlay helper
+ci: Gate deploy on successful build
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `ci`.
+
+## Nix
+
+**Attribute sets:** one attribute per line for multi-attribute sets.
+
+```nix
+# good
+programs.git = {
+  enable = true;
+  settings = { ... };
+};
+
+# avoid
+programs.git = { enable = true; settings = { ... }; };
+```
+
+**Function arguments:** destructure only what the module uses.
+
+```nix
+# good
+{ pkgs, config, ... }: { ... }
+
+# avoid — lists unused args
+{ pkgs, config, lib, inputs, outputs, ... }: { ... }
+```
+
+**String interpolation:** prefer `${}` over concatenation.
+
+```nix
+# good
+"${config.xdg.configHome}/nvim"
+
+# avoid
+config.xdg.configHome + "/nvim"
+```
+
+**`let...in`:** keep bindings close to where they're used rather than hoisting everything to the top of the file.
+
+**Comments:** explain *why*, not *what*. If removing the comment wouldn't confuse a future reader, don't write it.
+
+## YAML
+
+YAML style is enforced by `yamllint` in CI using `.yamllint.yml` as the config. There is no local install; the `build` workflow is the authoritative check.


### PR DESCRIPTION
## Summary

- Add `docs/` directory with five new files: `architecture.md`, `onboarding.md`, `style.md`, `customization.md`, and `ci.md`
- Slim `README.md` to a landing page with links into `docs/`; remove stale `pkgs/` reference
- Condense `CLAUDE.md` sections to agent-focused summaries with explicit references to the new docs

## Commits

- docs: Add docs/ directory and close issue #64

## Test plan

- [x] Verify all links in `README.md` resolve to the correct `docs/` files
- [x] Verify `pkgs/` no longer appears in `README.md`
- [x] Confirm `markdownlint-disable MD013` is present in all new markdown files

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)