### PR TITLE
chore: Add self-hosted Renovate for automated flake input updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,25 @@
+---
+name: renovate
+
+on:
+  schedule:
+    - cron: 0 6 * * 1
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: renovatebot/github-action@v41
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_PLATFORM: github

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,6 +7,7 @@
 |---|---|---|
 | `build` | PR to `main`, push to `main`, weekly (Wed) | `yamllint`, `nix-flake-check` |
 | `deploy` | `build` completes on `main` | `release-please` |
+| `renovate` | Weekly (Mon), `workflow_dispatch` | `renovate` |
 | `claude-code-review` | PR opened/updated | `claude-review` |
 | `claude` | Issues opened/assigned, and issue/PR comments and reviews mentioning `@claude` | `claude` |
 
@@ -21,3 +22,4 @@ Release management uses [release-please](https://github.com/googleapis/release-p
 - **YAML linting** is CI-only. `.yamllint.yml` is the config; `build` is the authoritative check.
 - **Flake validation** runs `nix flake check` via [DeterminateSystems/nix-installer-action](https://github.com/DeterminateSystems/nix-installer-action).
 - **Claude workflows** require the `CLAUDE_CODE_OAUTH_TOKEN` secret.
+- **Renovate** runs self-hosted via `renovatebot/github-action`, scoped to Nix only (`enabledManagers: ["nix"]`). It uses `GITHUB_TOKEN`, so PRs it opens do not automatically trigger `build` CI — run `build` manually via `workflow_dispatch` or the GitHub UI if validation is needed before merging. Dependabot handles `github-actions` updates separately and keeps `renovatebot/github-action` pinned.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["nix"]
+}


### PR DESCRIPTION
## Summary

- Adds \`renovate.json\` scoping Renovate exclusively to Nix (\`enabledManagers: ["nix"]\`)
- Adds \`.github/workflows/renovate.yml\` running the self-hosted Renovate CLI on a Monday 06:00 UTC cron
- Adds Renovate to the workflow overview table in \`docs/ci.md\`
- Leaves \`.github/dependabot.yml\` unchanged — Dependabot continues handling \`github-actions\` updates

## Design

Self-hosted mode was chosen over the Mend cloud app to avoid granting any third-party access to the repo. The workflow uses \`GITHUB_TOKEN\` (no PAT required) because Renovate is scoped to Nix only and never writes to \`.github/workflows/\`.

PRs that Renovate opens do not automatically trigger \`build\` CI — GitHub does not fire workflow events for PRs opened via \`GITHUB_TOKEN\`. Given that Renovate PRs only ever change \`flake.lock\` (low-risk, trivially reviewable hashes), this is an acceptable tradeoff. \`build\` CI can be triggered manually via \`workflow_dispatch\` or the GitHub UI before merging if needed.

Dependabot will auto-pin \`renovatebot/github-action\` going forward since it already covers the \`github-actions\` ecosystem.

## Test plan

- [ ] Manually trigger the \`renovate\` workflow via \`workflow_dispatch\` to confirm it runs without errors
- [ ] If \`flake.lock\` has upstream changes, confirm Renovate opens a PR and \`flake.lock\` is the only changed file
- [ ] If no upstream changes, confirm no PR is created (idempotency)
- [ ] Trigger a second run while a Renovate PR is already open — confirm no duplicate PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)