### PR TITLE
fix: Correct renovatebot/github-action version to v46

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: renovatebot/github-action@v41
+      - uses: renovatebot/github-action@v46
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:


### PR DESCRIPTION
## Summary

Fixes the `renovatebot/github-action` version from `v41` (nonexistent) to `v46` (current latest major). The workflow failed immediately on first `workflow_dispatch` run with "unable to find version v41".

🤖 Generated with [Claude Code](https://claude.com/claude-code)