### PR TITLE
fix: Use full semver tag for renovatebot/github-action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: renovatebot/github-action@v46
+      - uses: renovatebot/github-action@v46.1.14
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:


### PR DESCRIPTION
## Summary

`renovatebot/github-action` does not publish major version alias tags (`v46`, `v41`, etc.) — only full semver tags. Updates to `v46.1.14` (current latest). Dependabot will keep this pinned going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)