### PR TITLE
chore: Add issues: write permission to renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `issues: write` to the `renovate` workflow permissions
- Enables the Renovate Dependency Dashboard, which Renovate creates as a GitHub issue showing pending flake input updates and their status
- `config:recommended` already enables the Dashboard by default; the missing permission was the only blocker (logged as "Could not ensure issue" in prior runs)

## Notes

- The Dashboard issue will be publicly visible (public repo), but exposes nothing sensitive — all three flake inputs are public Nix registries
- Interactive checkboxes on the Dashboard are write-gated (only repo owner can interact)
- In this cron-based setup, checking a Dashboard checkbox takes effect on the next scheduled run (Monday 06:00 UTC) or a manual `workflow_dispatch`, not immediately

## Test plan

- [ ] Merge and trigger `renovate` via `workflow_dispatch`
- [ ] Confirm a "Dependency Dashboard" issue is created in the repo
- [ ] Confirm no regressions in the renovate workflow run log