### PR TITLE
fix: Skip Claude Code Review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,7 @@ jobs:
   claude-review:
     if: |
       github.event.pull_request.user.login != 'release-please[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.pull_request.author_association == 'OWNER' ||
        github.event.pull_request.author_association == 'MEMBER' ||
        github.event.pull_request.author_association == 'COLLABORATOR' ||


### PR DESCRIPTION
## Summary

- Adds `dependabot[bot]` to the exclusion list in the `claude-review` job's `if` condition, mirroring the existing `release-please[bot]` exclusion
- Fixes failing `Claude Code Review` checks on PRs #79, #80, and #81 opened by dependabot

## Root cause

`dependabot[bot]` is assigned `author_association: CONTRIBUTOR` by GitHub, so the existing guard passed it through to the Claude Code Action. The action then rejected the run internally: "Workflow initiated by non-human actor: dependabot (type: Bot)."

## After merging

Re-run the failed `Claude Code Review` check on PRs #79, #80, and #81. Dependabot PRs use the workflow from the base branch, so the updated condition takes effect immediately on re-run and the job will be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)