### PR TITLE
docs: Remove outdated nix-channel step from installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,9 @@ Clone the repository to your directory of choosing.
 git clone https://github.com/aglorei/dotfiles $HOME/github.com/aglorei/dotfiles
 ```
 
-### Step 2: Configure Nix
+### Step 2: Enable Flakes
 
-Add your channel of choice, update Nixpkgs.
-
-```sh
-nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-nix-channel --update
-```
-
-Optionally, enable flakes as an experimental feature [without additional command-line options](https://wiki.nixos.org/wiki/Flakes#Other_Distros,_without_Home-Manager).
+If flakes are not already enabled, opt in as an experimental feature [without additional command-line options](https://wiki.nixos.org/wiki/Flakes#Other_Distros,_without_Home-Manager).
 
 ### Steps 3–4: Configure and Activate
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->
## Summary

- Step 2 of the installation guide told users to run `nix-channel --add` and `nix-channel --update`, which are legacy commands with no effect on a flakes-based repo (all inputs are pinned in `flake.lock`).
- Replaced the step with a single sentence directing users to enable flakes if not already done, which is the only configuration actually needed.

## Test plan

- [ ] Read through the updated README installation steps end-to-end and confirm they are coherent and accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)