### PR TITLE
fix: Configure Renovate to detect and update flake.lock

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: renovatebot/github-action@v46.1.15
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          renovate-version: latest-full
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["nix"]
+  "enabledManagers": ["nix"],
+  "nix": {
+    "fileMatch": ["(^|/)flake\\.nix$"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary

- Add explicit `fileMatch: ["(^|/)flake\\.nix$"]` to the `nix` manager block — Renovate 43's default does not include `flake.nix`, causing `fileCount: 0` (confirmed in run [27123212842](https://github.com/aglorei/dotfiles/actions/runs/27123212842))
- Switch to `renovate-version: latest-full` so the nix binary is available for `narHash` computation when writing updated `flake.lock` entries
- Disable `vulnerabilityAlerts` — unsupported with `GITHUB_TOKEN` and irrelevant for Nix flake inputs (suppresses the WARN in issue #78)

## Test plan

- [ ] Merge this PR
- [ ] Trigger a manual run via Actions > renovate > Run workflow
- [ ] Confirm issue #78 lists `nixpkgs`, `nixpkgs-unstable`, and `home-manager` under Detected Dependencies
- [ ] Confirm a `flake.lock` update PR is opened if any inputs have newer commits available

🤖 Generated with [Claude Code](https://claude.com/claude-code)