### PR TITLE
fix: Correct Renovate full image tag from latest-full to full

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: renovatebot/github-action@v46.1.15
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          renovate-version: latest-full
+          renovate-version: full
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github


### PR DESCRIPTION
## Summary

- `latest-full` does not exist on `ghcr.io/renovatebot/renovate` — run [27169348743](https://github.com/aglorei/dotfiles/actions/runs/27169348743) failed with `manifest unknown`
- The correct floating tag for the latest full image on GHCR is `full`
- `full` includes the nix binary needed for `narHash` computation when updating `flake.lock`

Follows up on #84.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a manual run via Actions > renovate > Run workflow
- [ ] Confirm the run pulls `ghcr.io/renovatebot/renovate:full` without error
- [ ] Confirm issue #78 lists `nixpkgs`, `nixpkgs-unstable`, and `home-manager` under Detected Dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)