### PR TITLE
fix: Enable lockFileMaintenance to update flake.lock via nix flake update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,8 @@
   },
   "vulnerabilityAlerts": {
     "enabled": false
+  },
+  "lockFileMaintenance": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
## Summary

- Enable `lockFileMaintenance` in `renovate.json`

The `nix` manager's extraction function looks for fetch expressions (`fetchTarball`, `fetchFromGitHub`, etc.) — not flake `inputs.*.url` declarations. As a result, `flake.nix` yields `fileCount: 0` through the normal package-tracking path and no update PRs are created.

`lockFileMaintenance` bypasses extraction entirely: Renovate runs `nix flake update` directly (using the nix binary in the `full` image from #85) and opens a single PR whenever `flake.lock` changes. The default schedule (`before 5am on Monday`) aligns with the existing cron trigger.

Follows up on #84 and #85.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a manual run via Actions > renovate > Run workflow
- [ ] Confirm a "Lock file maintenance" PR is opened (or issue #78 shows it pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)