### PR TITLE
fix: Migrate fileMatch to managerFilePatterns and remove lockFileMaintenance schedule restriction

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,15 @@
   "extends": ["config:recommended"],
   "enabledManagers": ["nix"],
   "nix": {
-    "fileMatch": ["(^|/)flake\\.nix$"]
+    "managerFilePatterns": [
+      "/(^|/)flake\\.nix$/"
+    ]
   },
   "vulnerabilityAlerts": {
     "enabled": false
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": ["at any time"]
   }
 }


### PR DESCRIPTION
## Summary

- Rename `fileMatch` → `managerFilePatterns` (with `/regex/` syntax) per Renovate's deprecation migration — incorporates what Renovate proposed in #87, which is now closed
- Set `lockFileMaintenance.schedule: ["at any time"]` — the default `["before 5am on Monday"]` is incompatible with the `0 6 * * 1` cron (fires after the window) and causes manual runs to be silently skipped

Follows up on #84, #85, #86.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a manual run via Actions > renovate > Run workflow
- [ ] Confirm a "Lock file maintenance" PR is opened updating `flake.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)