### PR TITLE
chore(ci): Enable debug logging for Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,3 +25,4 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github
+          LOG_LEVEL: debug


### PR DESCRIPTION
## Summary

- Adds `LOG_LEVEL: debug` to the Renovate workflow environment to expose full file discovery and lock file maintenance decisions in the run logs

## Context

Five PRs in, `lockFileMaintenance` still does not produce a `flake.lock` update PR. Run logs show `fileCount: 0` and `managers: {}` after every run. Debug output will let us see exactly why the `nix` manager isn't activating and whether `lockFileMaintenance` is being considered or silently skipped.

## Test plan

- [ ] Merge and trigger a manual workflow run
- [ ] Read debug output to identify root cause
- [ ] Revert or replace this PR once diagnosis is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)