### PR TITLE
fix(ci): Fix Renovate nix managerFilePatterns regex and remove debug logging

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,4 +25,3 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github
-          LOG_LEVEL: debug

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "enabledManagers": ["nix"],
   "nix": {
     "managerFilePatterns": [
-      "/(^|/)flake\\.nix$/"
+      "**/flake.nix"
     ]
   },
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Fixes `managerFilePatterns` pattern that was silently matching nothing
- Removes `LOG_LEVEL: debug` added in #89 for diagnosis

## Root cause

The pattern `/(^|/)flake\.nix$/` contains a `/` inside the regex body. Renovate's RE2 parser finds the next `/` as the closing delimiter, so it receives `(^|` as the pattern (invalid), which matches nothing. This caused the nix manager to report "nix is disabled" on every run.

The pattern was generated by Renovate's own config migration tool (PR #87), which produced a broken output for this specific case.

## Fix

Switched to the glob `**/flake.nix` — targets only flake declaration files, uses the primary supported format for `managerFilePatterns`, and has no regex parsing edge cases. The lock file (`flake.lock`) does not need to be matched; `lockFileMaintenance` updates it automatically in the directory where `flake.nix` is found.

## Verification

Merge and trigger a manual workflow run. Expect to see a "Lock file maintenance" PR updating `flake.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)