### PR TITLE
fix(ci): Switch managerFilePatterns to /flake\.nix$/ regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "enabledManagers": ["nix"],
   "nix": {
     "managerFilePatterns": [
-      "**/flake.nix"
+      "/flake\\.nix$/"
     ]
   },
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Replaces `**/flake.nix` glob with `/flake\.nix$/` regex in `nix.managerFilePatterns`
- Debug run confirmed the glob does not match `flake.nix` at the repo root in Renovate's implementation (`**` requires at least one path component)
- The regex form `/flake\.nix$/` has no inner `/`, so RE2 parses it correctly as `flake\.nix$`, matching any path ending in `flake.nix` including the root-level file

## Test plan

- [ ] Confirm CI passes
- [ ] Merge and trigger a manual Renovate run
- [ ] Verify `fileCount > 0` in run stats (previously always 0)
- [ ] Confirm a "Lock file maintenance" PR is opened to update `flake.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)