### PR TITLE
feat: Add GitHub Copilot CLI

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -73,16 +73,16 @@ The overlay is applied in each user's `global/default.nix`. See [`docs/architect
 
 ## GitHub Copilot CLI
 
-Installed from `pkgs.github-copilot-cli`. Authenticate and grant the required Copilot scope:
+Installed from `pkgs.github-copilot-cli`. The package provides the `copilot` binary, a standalone
+AI coding agent. Authenticate once with:
 
 ```sh
-gh auth login
-gh auth refresh --hostname github.com --scopes copilot
+copilot login
 ```
 
 Then use:
 
 ```sh
-gh copilot suggest "create a tarball of the current directory"
-gh copilot explain "git rebase -i HEAD~3"
+copilot                                         # interactive session
+copilot --prompt "fix the bug in main.go"       # non-interactive
 ```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -70,3 +70,18 @@ home.packages = [
 ```
 
 The overlay is applied in each user's `global/default.nix`. See [`docs/architecture.md`](architecture.md) for details.
+
+## GitHub Copilot CLI
+
+Installed from `pkgs.github-copilot-cli`. Authenticate once with:
+
+```sh
+gh auth login
+```
+
+Then use:
+
+```sh
+gh copilot suggest "create a tarball of the current directory"
+gh copilot explain "git rebase -i HEAD~3"
+```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -77,7 +77,7 @@ Installed from `pkgs.github-copilot-cli`. Authenticate and grant the required Co
 
 ```sh
 gh auth login
-gh auth refresh -h github.com -s copilot
+gh auth refresh --hostname github.com --scopes copilot
 ```
 
 Then use:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -73,10 +73,11 @@ The overlay is applied in each user's `global/default.nix`. See [`docs/architect
 
 ## GitHub Copilot CLI
 
-Installed from `pkgs.github-copilot-cli`. Authenticate once with:
+Installed from `pkgs.github-copilot-cli`. Authenticate and grant the required Copilot scope:
 
 ```sh
 gh auth login
+gh auth refresh -h github.com -s copilot
 ```
 
 Then use:

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780361225,
-        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
+        "lastModified": 1780883961,
+        "narHash": "sha256-WU6SUrESuPiEXEUvX4D51AgWrXRJty+sLJBwBaDBGqE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
+        "rev": "4eb4fec41674d5b059aa2eedf0f98453890546fa",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780203844,
-        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "lastModified": 1780902259,
+        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -11,6 +11,7 @@
     pkgs.awscli2
     pkgs.azure-cli
     pkgs.gh
+    pkgs.github-copilot-cli
     pkgs.google-cloud-sdk
 
     # Containers


### PR DESCRIPTION
## Summary

- Updates all flake inputs (`nixpkgs`, `nixpkgs-unstable`, `home-manager`) to their latest revisions (2026-06-08)
- Adds `pkgs.github-copilot-cli` to the `# Client` block in `commons.nix`
- Documents authentication and usage in `docs/customization.md`

Note: `gh-copilot` was removed from nixpkgs in January 2026 (upstream archived); `github-copilot-cli` is the nixpkgs-recommended replacement, available in stable nixos-26.05.

## Test plan

- [ ] Run `nix flake check` (passes in CI)
- [ ] Run `nix run home-manager/release-26.05 -- build --flake .#$(whoami)@$(hostname -s)` to verify the build resolves `github-copilot-cli`
- [ ] After activation, confirm `gh copilot suggest` is available in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)