### PR TITLE
chore: Add .claude/ to global gitignore

### DIFF
--- a/modules/home-manager/assets/git/ignore
+++ b/modules/home-manager/assets/git/ignore
@@ -39,3 +39,9 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Claude Code #
+################
+.claude/*
+!.claude/settings.json
+!.claude/commands


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->
## Summary

- Adds `.claude/*` to the global gitignore so Claude Code machine-local files (credentials, memory, plans, `settings.local.json`) are never committed
- Re-includes `.claude/settings.json` (shared project config) and `.claude/commands` (shared slash commands) via negation patterns
- Uses `.claude/*` rather than `.claude/` so negation patterns inside the directory are not blocked by git

Closes #95

## Test plan

- [x] `nix flake check` passes
- [ ] After `home-manager switch`, confirm `.claude/settings.local.json` is gitignored and `.claude/settings.json` / `.claude/commands/` are not in a repo with a `.claude/` directory