### PR TITLE
feat: Add terraform-docs and pre-commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780883961,
-        "narHash": "sha256-WU6SUrESuPiEXEUvX4D51AgWrXRJty+sLJBwBaDBGqE=",
+        "lastModified": 1781981105,
+        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4eb4fec41674d5b059aa2eedf0f98453890546fa",
+        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -44,6 +44,9 @@
     # Rust
     pkgs.cargo
 
+    # SCM
+    pkgs.pre-commit
+
     # Terminal
     pkgs.tmux
 

--- a/modules/home-manager/commons.nix
+++ b/modules/home-manager/commons.nix
@@ -49,6 +49,7 @@
 
     # Terraform
     pkgs.terraform
+    pkgs.terraform-docs
 
     # Utility
     pkgs.fasd


### PR DESCRIPTION
## Summary

- Updates flake.lock to pick up upstream changes (home-manager, nixpkgs, nixpkgs-unstable refreshed to 2026-06-11 to 2026-06-20 range)
- Adds `pkgs.terraform-docs` alongside the existing `pkgs.terraform` in the Terraform section of `modules/home-manager/commons.nix`
- Adds `pkgs.pre-commit` under a new SCM section in `modules/home-manager/commons.nix`

## Test plan

- `nix flake check` passes (verified locally)
- CI build workflow validates on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J9dpvnvCo451wZFSZKzAh